### PR TITLE
default chrome instance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,16 +1,27 @@
 {
-	"version": "0.2.0",
-	"configurations": [
-	    {
-                "name": "Debug",
-                "type": "chrome",
-                "request": "launch",
-                "webRoot": "${workspaceRoot}",
-                "url": "http://localhost:3000/index.html", 
-                "userDataDir": "${workspaceRoot}/.vscode/chrome",
-                "sourceMaps": true,
-                "preLaunchTask": "development",
-                "smartStep": true
-            }
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug",
+      "type": "chrome",
+      "request": "launch",
+      "webRoot": "${workspaceRoot}",
+      "url": "http://localhost:3000/index.html",
+      "userDataDir": "${workspaceRoot}/.vscode/chrome",
+      "sourceMaps": true,
+      "preLaunchTask": "development",
+      "smartStep": true
+    },
+    {
+      "name": "Debug",
+      "type": "chrome",
+      "request": "launch",
+      "webRoot": "${workspaceRoot}",
+      "url": "http://localhost:3000/index.html",
+      "runtimeExecutable": "/usr/bin/google-chrome-stable",
+      "sourceMaps": true,
+      "preLaunchTask": "development",
+      "smartStep": true
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,22 @@ A react boilerplate project for Visual Studio Code based on [react-transform-boi
 3.   make sure you have [vscode-chrome-debug](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) and [vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) extension installed
 4.   press <kbd>F1</kbd> > `Run Task` > `install` (or `npm install`) to install all dependencies
 
-
+## Chrome instances
+By default, the starter kit launches a new instance of Chrome, with none of the default user's plugins, settings, etc.  If you'd prefer to launch the debugger in an instance of Chrome under your default profile, add the path to your Chrome executable to the 'Debug with default Chrome profile' object in `.vscode/launch.json`:
+```
+// As it might in a Ubuntu environment
+ {
+   "name": "Debug",
+   "type": "chrome",
+   "request": "launch",
+   "webRoot": "${workspaceRoot}",
+   "url": "http://localhost:3000/index.html", 
+    "runtimeExecutable": "/usr/bin/google-chrome-stable",
+   "sourceMaps": true,
+   "preLaunchTask": "development",
+   "smartStep": true
+}
+```
 ## Visual Studio Code shortcuts
 
 *   <kbd>F5</kbd> to start debugging


### PR DESCRIPTION
the config launches a custom instance of Chrome with a fresh data directory. this is fine for a lot of cases, but in my case:

* i wanted to access custom launch flags i'd already added to `google-chrome.desktop` in my ubuntu environ
* i didn't want to reinstall other development extensions (eg redux devtools)

so i added a `launch.json` option that launches the default Chrome profile on the system and updated readme.  user just needs to add path to their local chrome

the git history of the PR is a little messy b/c i'm absolutely terrible w/ git, btw--sorry for that!